### PR TITLE
Fix missing Steamworks libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN set -x \
 	&& chown -R steam:steam ${STEAMAPPDIR} \
 	&& ${STEAMCMDDIR}/steamcmd.sh +login anonymous +force_install_dir ${STEAMAPPDIR} \
 		+@sSteamCmdForcePlatformType windows +app_update ${STEAMAPPID} +quit \
+	&& ${STEAMCMDDIR}/steamcmd.sh +login anonymous +force_install_dir /home/steam/steamworks_sdk \
+		+@sSteamCmdForcePlatformType windows +app_update 1007 +quit \
+	&& cp /home/steam/steamworks_sdk/*64.dll ${STEAMAPPDIR}/ \
 	&& apt-get remove --purge -y \
 		wget \
 	&& apt-get clean autoclean \


### PR DESCRIPTION
Added **Steamworks** libraries alongside the RoR2 executable as suggested [here](https://github.com/avivace/ror2-server/issues/1#issuecomment-672383266)
This should also fix this [issue](https://github.com/avivace/ror2-server/issues/7).