### PR TITLE
Fix for multiple containers on a single host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ ENV R2_HEARTBEAT 0
 ENV R2_HOSTNAME "A Risk of Rain 2 dedicated server"
 ENV R2_PSW ""
 ENV R2_ENABLE_MODS false
+ENV R2_SV_PORT 27015
+ENV R2_QUERY_PORT
 
 # Prepare the environment
 # We need Wine 3 and xvfb
@@ -65,4 +67,6 @@ VOLUME ${STEAMAPPDIR}
 ENTRYPOINT ${STEAMAPPDIR}/entry.sh
 
 # Expose ports
-EXPOSE 27015/udp
+EXPOSE ${R2_SV_PORT}/udp
+EXPOSE ${R2_QUERY_PORT}/udp
+EXPOSE ${R2_QUERY_PORT}/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV R2_HOSTNAME "A Risk of Rain 2 dedicated server"
 ENV R2_PSW ""
 ENV R2_ENABLE_MODS false
 ENV R2_SV_PORT 27015
-ENV R2_QUERY_PORT
+ENV R2_QUERY_PORT 27016
 
 # Prepare the environment
 # We need Wine 3 and xvfb

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ docker run -p 27015:27015/udp -v /path/to/directory:/home/steam/ror2-dedicated/m
 
 ### Known Issues
 
-- Currently, reporting to the official server browser requires a patched DLL. See this [issue](https://github.com/avivace/ror2-server/issues/1).
 - For some reason, `winecfg` returns before completing the creation of the configuration files, making any subsequent call of `xvfb` fail. The current (trash) workaround is to just wait 5 seconds before firing Wine in the virtual framebuffer.
 
 ## Develop

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you see something like this:
 Could not load config /Config/server_pregame.cfg: Could not find file "Z:\home\steam\ror2-dedicated\Risk of Rain 2_Data\Config\server_pregame.cfg"
 ```
 
-Beware that this kind of warning messages is non blocking, they are just warnings and the server initialization will proceed as normal.
+Be aware that these kind of warning messages are non blocking, they are just warnings and the server initialization will proceed as normal.
 
 ### Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ By default, the server has no password and runs on UDP port 27015.
 If you want to start the server on port **25000** with password **hello**:
 
 ```
-docker run -p 25000:27015/udp -e R2_PSW='hello' avivace/ror2server:latest
+docker run -p 25000:25000/udp -e R2_PSW='hello' -e R2_SV_PORT=25000 avivace/ror2server:latest
 ```
 
 Players will then join with:
@@ -35,14 +35,19 @@ Players will then join with:
 ```
 cl_password "hello"; connect "SERVER_IP:25000";
 ```
-
+If you additionally wanted to list it in the server browser and give it a name of **Cool Server**:
+```
+docker run -p 25000:25000/udp -p 25001:25001 -e R2_HEARTBEAT=1 -e R2_HOSTNAME='Cool Server' -e R2_PSW='hello' -e R2_SV_PORT=25000 -e R2_QUERY_PORT=25001 avivace/ror2server:latest
+```
 You can pass these additional environment variables to customise your server configuration:
 
-- `R2_PLAYERS`, the maximum number of players
-- `R2_HEARTBEAT`, set to 1 to advertise to the master server (not currently working). If you enable this, you need to add `-p 27016:27016` to your Docker command.
+- `R2_PLAYERS`, the maximum number of players default is 4, max is 16.
+- `R2_HEARTBEAT`, set to 1 to advertise to the master server. If you enable this, you need to set the next env variable.
+- `R2_QUERY_PORT`, the listen port for the steamworks connection, needed to list the server in the browser, you need to add -p port:port to your docker command
 - `R2_HOSTNAME`, the name that will appear in the server browser
 - `R2_PSW`, the password someone must provide to join this server
 - `R2_ENABLE_MODS`, boolean flag used for enabling mods (given that they are correctly mounted as described below)
+- `R2_SV_PORT`, the listen port for the server, make sure that this matches your -p port:port/udp Docker command
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
  
 [![Docker Pulls](https://img.shields.io/docker/pulls/avivace/ror2server?style=flat-square)](https://hub.docker.com/r/avivace/ror2server)
 
-Host your Risk of Rain 2 dedicated server anywhere using Docker. [Guide on Steam](https://steamcommunity.com/sharedfiles/filedetails/?id=2077564253).
+Host your Risk of Rain 2 dedicated server anywhere using Docker. Powered by Wine and the X virtual framebuffer to seamlessy run on Linux machines.
+
+[Guide on Steam](https://steamcommunity.com/sharedfiles/filedetails/?id=2077564253).
+
 
 ## Quickstart
 
@@ -27,7 +30,7 @@ By default, the server has no password and runs on UDP port 27015.
 If you want to start the server on port **25000** with password **hello**:
 
 ```
-docker run -p 25000:25000/udp -e R2_PSW='hello' -e R2_SV_PORT=25000 avivace/ror2server:latest
+docker run -p 25000:27015/udp -e R2_PSW='hello' avivace/ror2server:latest
 ```
 
 Players will then join with:
@@ -35,19 +38,31 @@ Players will then join with:
 ```
 cl_password "hello"; connect "SERVER_IP:25000";
 ```
-If you additionally wanted to list it in the server browser and give it a name of **Cool Server**:
-```
-docker run -p 25000:25000/udp -p 25001:25001 -e R2_HEARTBEAT=1 -e R2_HOSTNAME='Cool Server' -e R2_PSW='hello' -e R2_SV_PORT=25000 -e R2_QUERY_PORT=25001 avivace/ror2server:latest
-```
+
 You can pass these additional environment variables to customise your server configuration:
 
-- `R2_PLAYERS`, the maximum number of players default is 4, max is 16.
-- `R2_HEARTBEAT`, set to 1 to advertise to the master server. If you enable this, you need to set the next env variable.
-- `R2_QUERY_PORT`, the listen port for the steamworks connection, needed to list the server in the browser, you need to add -p port:port to your docker command
-- `R2_HOSTNAME`, the name that will appear in the server browser
-- `R2_PSW`, the password someone must provide to join this server
-- `R2_ENABLE_MODS`, boolean flag used for enabling mods (given that they are correctly mounted as described below)
-- `R2_SV_PORT`, the listen port for the server, make sure that this matches your -p port:port/udp Docker command
+- `R2_PLAYERS`, the maximum number of players;
+- `R2_HEARTBEAT`, set to `1` to advertise to the master server and list your server in the internal server browser. If you enable this, append `-p 27016:27016` to your Docker command;
+- `R2_QUERY_PORT`, the listen port for the steamworks connection, needed to list the server in the game browser on a alternate port, you need to add -p port:port to your Docker command;
+- `R2_SV_PORT`, the listen port for the game server, needed to list the server in the game browser on a alternate port, you need to add -p port:port to your Docker command;
+- `R2_HOSTNAME`, the name that will appear in the server browser;
+- `R2_PSW`, the password someone must provide to join this server;
+- `R2_ENABLE_MODS`, set to `1` to enable mod support (given you mounted the mod folders as described below).
+
+Append one or more `-e VARIABLENAME=VALUE` to your Docker command to set environment variables.
+
+## Mod support
+
+To install and enable mods server side, you'll need a directory containing:
+
+- The **BepInEx** folder with the desired mods
+- The `doorstop_config.ini` and `winhttp.dll` files, both shipped with the BepInEx version you intend to use
+
+Supposing your mod directory is in `/path/to/directory`, you can start your server as follows:
+
+```bash
+docker run -p 27015:27015/udp -v /path/to/directory:/home/steam/ror2-dedicated/mods -e R2_ENABLE_MODS=true avivace/ror2server:latest
+```
 
 ## FAQ
 
@@ -55,23 +70,27 @@ You can pass these additional environment variables to customise your server con
 
 Yes, any Linux box works. For decent performance, you need 3 GB of free space and at least 2 GB of RAM.
 
-#####  Can I install mods?
+##### Server is stuck at "Unloading unused Assets"
 
-To install and enable mods server side, you'll need a directory containing:
-- BepInEx folder with the desired mods
-- `doorstop_config.ini` and `winhttp.dll` (both shipped with the BepInEx version you're using)
+That line is usually the last one of the initialization process. It usually means your server is working correctly, that is not a blocking error. If you can't connect to your server at that point, it's probably a network issue.
 
-After that you're ready to start your server as follows:
+##### Server is stuck at "Could not load config ..."
 
-```bash
-docker run -p 27015:27015/udp -v /path/to/directory:/home/steam/ror2-dedicated/mods -e R2_ENABLE_MODS=true avivace/ror2server:latest
+If you see something like this:
+
+```
+Could not load config /Config/server_pregame.cfg: Could not find file "Z:\home\steam\ror2-dedicated\Risk of Rain 2_Data\Config\server_pregame.cfg"
 ```
 
-### Known Issues
+Beware that this kind of warning messages is non blocking, they are just warnings and the server initialization will proceed as normal.
 
-- For some reason, `winecfg` returns before completing the creation of the configuration files, making any subsequent call of `xvfb` fail. The current (trash) workaround is to just wait 5 seconds before firing Wine in the virtual framebuffer.
+### Acknowledgements
 
-## Develop
+Thanks to [InfernalPlacebo](https://github.com/InfernalPlacebo) and [Vam-Jam](https://github.com/Vam-Jam).
+
+Built by [Manuele](https://github.com/dubvulture), [Davide Casella](https://github.com/dcasella), [Fabio Nicolini](https://github.com/fnicolini), [Antonio Vivace](https://github.com/avivace).
+
+### Development commands
 
 ```bash
 git clone https://github.com/avivace/ror2-server
@@ -85,9 +104,3 @@ docker logs -f ror2-server
 # Open console in RoR
 wmctrl -R Risk && xdotool key ctrl+alt+grave
 ```
-
-### Acknowledgements
-
-Thanks to [InfernalPlacebo](https://github.com/InfernalPlacebo) and [Vam-Jam](https://github.com/Vam-Jam).
-
-Built by [Manuele](https://github.com/dubvulture), [Davide Casella](https://github.com/dcasella), [Fabio Nicolini](https://github.com/fnicolini), [Antonio Vivace](https://github.com/avivace).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To install and enable mods server side, you'll need a directory containing:
 Supposing your mod directory is in `/path/to/directory`, you can start your server as follows:
 
 ```bash
-docker run -p 27015:27015/udp -v /path/to/directory:/home/steam/ror2-dedicated/mods -e R2_ENABLE_MODS=true avivace/ror2server:latest
+docker run -p 27015:27015/udp -v /path/to/directory:/home/steam/ror2-dedicated/mods -e R2_ENABLE_MODS=1 avivace/ror2server:latest
 ```
 
 ## FAQ

--- a/default_config.cfg
+++ b/default_config.cfg
@@ -1,10 +1,15 @@
-//
-// Override default parameters
-//
-sv_maxplayers ${R2_PLAYERS}; // The maximum number of players.
-steam_server_heartbeat_enabled ${R2_HEARTBEAT}; // Set to 0 to not advertise to the master server.
-sv_hostname "${R2_HOSTNAME}"; // The name that will appear in the server browser.
-sv_port ${R2_SV_PORT}; // The port that the server will bind to. You cannot have multiple server instances with overlapping ports. Default RoR2 port
+// Risk of Rain 2 dedicated server configuration
+// This file gets populated with the environment variables so you shouldn't need to edit anything
+// Default values are listed in the Dockerfile
+// The maximum number of players
+sv_maxplayers ${R2_PLAYERS};
+// Set to 0 to not advertise to the master server
+steam_server_heartbeat_enabled ${R2_HEARTBEAT};
+// The name that will appear in the server browser
+sv_hostname "${R2_HOSTNAME}";
+// The port that the server will bind to. You cannot have multiple server instances with overlapping ports. (Default RoR2 port)
+sv_port ${R2_SV_PORT};
 steam_server_query_port ${R2_QUERY_PORT};
 steam_server_steam_port 0;
-sv_password "${R2_PSW}"; // The password someone must provide to join this server. Leave empty if none. This is obviously not encrypted so don't use anything sensitive.
+// The password someone must provide to join this server. Leave empty if none. This is obviously not encrypted so don't use anything sensitive.
+sv_password "${R2_PSW}";

--- a/default_config.cfg
+++ b/default_config.cfg
@@ -4,7 +4,7 @@
 sv_maxplayers ${R2_PLAYERS}; // The maximum number of players.
 steam_server_heartbeat_enabled ${R2_HEARTBEAT}; // Set to 0 to not advertise to the master server.
 sv_hostname "${R2_HOSTNAME}"; // The name that will appear in the server browser.
-sv_port 27015; // The port that the server will bind to. You cannot have multiple server instances with overlapping ports. Default RoR2 port
-steam_server_query_port 27016;
+sv_port ${R2_SV_PORT}; // The port that the server will bind to. You cannot have multiple server instances with overlapping ports. Default RoR2 port
+steam_server_query_port ${R2_QUERY_PORT};
 steam_server_steam_port 0;
 sv_password "${R2_PSW}"; // The password someone must provide to join this server. Leave empty if none. This is obviously not encrypted so don't use anything sensitive.


### PR DESCRIPTION
Once 1.0.1.1 was released and the server container started to work, I quickly found that getting more than one server to run did not work. Using:

http://api.steampowered.com/ISteamApps/GetServersAtAddress/v0001/?format=json&addr=IP_HERE

Along with a couple dedicated servers on a windows box helped me to understand that steamworks uses the configured port in server.cfg to report which port the server is running, as well as which port it is using to communicate with steamworks.
I tried using configs that looked similar to this on the windows box:

sv_port 27015; 
steam_server_query_port 26990;
steam_server_steam_port 26991;

and this on the second: 

sv_port 27015; 
steam_server_query_port 26992;
steam_server_steam_port 26993;

after they started up you could see both servers in the browser, however when you tried to connect it would crash the game.
Example of the response I got for my server with this configuration:

{"response":{"success":true,"servers":[{"addr":"XXX.XXX.XXX.XXX:26990","gmsindex":65534,"appid":632360,"gamedir":"Risk of Rain 2","region":-1,"secure":true,"lan":false,"gameport":**27015**,"specport":0},{"addr":"65.49.84.186:26992","gmsindex":65534,"appid":632360,"gamedir":"Risk of Rain 2","region":-1,"secure":true,"lan":false,"gameport":**27015**,"specport":0}]}}

I then tried it with the configs looking like this:

sv_port 26901; 
steam_server_query_port 26911;
steam_server_steam_port 0;

and

sv_port 26902; 
steam_server_query_port 26912;
steam_server_steam_port 0;

and got:

{"response":{"success":true,"servers":[{"addr":"XXX.XXX.XXX.XXX:26911","gmsindex":65534,"appid":632360,"gamedir":"Risk of Rain 2","region":-1,"secure":true,"lan":false,"gameport":**26901**,"specport":0},{"addr":"65.49.84.186:26912","gmsindex":65534,"appid":632360,"gamedir":"Risk of Rain 2","region":-1,"secure":true,"lan":false,"gameport":**26902**,"specport":0}]}}

I was also able to connect and play on both of them.

I then edited the dockerfile and the default_config with some additional env variables to make it possible to set the sv port and query port and then started up containers with:

docker run -d -p 26901:26901/udp -p 26911:26911/udp -p 26911:26911/tcp --name ror2server -e R2_HOSTNAME="Cool Server" -e R2_HEARTBEAT=1 -e R2_PLAYERS=8 -e R2_SV_PORT=26901 -e R2_QUERY_PORT=26911 ror2serverry:latest
and
docker run -d -p 26902:26902/udp -p 26912:26912/udp -p 26912:26912/tcp --name ror2server -e R2_HOSTNAME="Cool Server 2" -e R2_HEARTBEAT=1 -e R2_PLAYERS=8 -e R2_SV_PORT=26901 -e R2_QUERY_PORT=26911 ror2serverry:latest

(ror2serverry was a local image build after the edits) and was able to connect and play on both of them. I then spun up 10 and all 10 worked as well.

I know this is not how Docker is supposed to work, but the server doesn't seem to like the Docker way at all.