### PR TITLE
Only expose UDP ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,3 @@ ENTRYPOINT ${STEAMAPPDIR}/entry.sh
 # Expose ports
 EXPOSE ${R2_SV_PORT}/udp
 EXPOSE ${R2_QUERY_PORT}/udp
-EXPOSE ${R2_QUERY_PORT}/tcp

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ By default, the server has no password and runs on UDP port 27015.
 If you want to start the server on port **25000** with password **hello**:
 
 ```
-docker run -p 25000:27015/udp -e R2_PSW='hello' avivace/ror2server:latest
+docker run -p 25000:25000/udp -e R2_SV_PORT=25000 -e R2_PSW='hello' avivace/ror2server:latest
 ```
 
 Players will then join with:
@@ -42,9 +42,9 @@ cl_password "hello"; connect "SERVER_IP:25000";
 You can pass these additional environment variables to customise your server configuration:
 
 - `R2_PLAYERS`, the maximum number of players;
-- `R2_HEARTBEAT`, set to `1` to advertise to the master server and list your server in the internal server browser. If you enable this, append `-p 27016:27016` to your Docker command;
-- `R2_QUERY_PORT`, the listen port for the steamworks connection, needed to list the server in the game browser on a alternate port, you need to add -p port:port to your Docker command;
-- `R2_SV_PORT`, the listen port for the game server, needed to list the server in the game browser on a alternate port, you need to add -p port:port to your Docker command;
+- `R2_HEARTBEAT`, set to `1` to advertise to the master server and list your server in the internal server browser. If you enable this, add `-p 27016:27016/udp` to your Docker command;
+- `R2_QUERY_PORT`, the listen port for the steamworks connection, needed to list the server in the game browser on a alternate port, you need to add -p port:port/udp to your Docker command;
+- `R2_SV_PORT`, the listen port for the game server, needed to list the server in the game browser on a alternate port, you need to add -p port:port/udp to your Docker command;
 - `R2_HOSTNAME`, the name that will appear in the server browser;
 - `R2_PSW`, the password someone must provide to join this server;
 - `R2_ENABLE_MODS`, set to `1` to enable mod support (given you mounted the mod folders as described below).


### PR DESCRIPTION
Finally cleaning up the required ports and protocols.
This should make it clear that the server only uses UDP for its network communications.