### PR TITLE
Change mods volume to `/home/steam/ror2ds-mods`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL authors="Fabio Nicolini <fabionicolini48@gmail.com>, Antonio Vivace <anton
 
 ENV STEAMAPPID 1180760
 ENV STEAMAPPDIR /home/steam/ror2-dedicated
+ENV MODDIR /home/steam/ror2ds-mods
 
 # Default server parameters
 ENV R2_PLAYERS 4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1> <img src="https://i.imgur.com/UIQSMEs.png" height=45> Risk of Rain 2 dockerized server </h1>
- 
+
 [![Docker Pulls](https://img.shields.io/docker/pulls/avivace/ror2server?style=flat-square)](https://hub.docker.com/r/avivace/ror2server)
 
 Host your Risk of Rain 2 dedicated server anywhere using Docker. Powered by Wine and the X virtual framebuffer to seamlessy run on Linux machines.
@@ -25,7 +25,7 @@ connect "<SERVER_IP>:27015";
 
 Replace `SERVER_IP` with the public IP of the server running the Docker Image.
 
-By default, the server has no password and runs on UDP port 27015. 
+By default, the server has no password and runs on UDP port 27015.
 
 ## Customize configuration
 
@@ -76,7 +76,7 @@ To install and enable mods server side, you'll need a directory containing:
 Supposing your mod directory is in `/path/to/directory`, you can start your server as follows:
 
 ```bash
-docker run -p 27015:27015/udp -v /path/to/directory:/home/steam/ror2-dedicated/mods -e R2_ENABLE_MODS=1 avivace/ror2server:latest
+docker run -p 27015:27015/udp -v /path/to/directory:/home/steam/ror2ds-mods -e R2_ENABLE_MODS=1 avivace/ror2server:latest
 ```
 
 Beware that some mods requires the client to also have them installed.

--- a/entry.sh
+++ b/entry.sh
@@ -8,9 +8,10 @@ envsubst < "default_config.cfg" > "${STEAMAPPDIR}/Risk of Rain 2_Data/Config/ser
 
 if [ "${R2_ENABLE_MODS}" = 1 ]; then
     echo "Setting up mods..."
-    cp -r ${STEAMAPPDIR}/mods/BepInEx             ${STEAMAPPDIR}/BepInEx
-    cp    ${STEAMAPPDIR}/mods/doorstop_config.ini ${STEAMAPPDIR}/doorstop_config.ini
-    cp    ${STEAMAPPDIR}/mods/winhttp.dll         ${STEAMAPPDIR}/winhttp.dll
+    rm -rf ${STEAMAPPDIR}/BepInEx
+    cp -r  ${MODDIR}/BepInEx             ${STEAMAPPDIR}/BepInEx
+    cp     ${MODDIR}/doorstop_config.ini ${STEAMAPPDIR}/doorstop_config.ini
+    cp     ${MODDIR}/winhttp.dll         ${STEAMAPPDIR}/winhttp.dll
     DLL="winhttp=n,b"
 fi
 


### PR DESCRIPTION
The latest version of RoR2DS requires write access to `${STEAMAPPDIR}/Mods/enable_mods.txt`, which can halt the server if the mods volume, which is `${STEAMAPPDIR}/mods`, is mounted on a read-only directory.

Moving the mods volume out of the game data directory may be a better practice.

**Also another minor improvement:** When the docker container is reused (e.g. using `docker-compose` to create container but not `docker run`), the mods directory `${STEAMAPPDIR}/BepInEx` should be cleaned first, to prevent deleted plugins from taking effect again.