### PR TITLE
Add support for changing the gamemode via the environment (i.e. Simulacrum)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV R2_PSW ""
 ENV R2_ENABLE_MODS false
 ENV R2_SV_PORT 27015
 ENV R2_QUERY_PORT 27016
+ENV R2_GAMEMODE "ClassicRun"
 
 # Prepare the environment
 # We need Wine 3 and xvfb

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ You can pass these additional environment variables to customise your server con
 - `R2_QUERY_PORT`, the listen port for the Steamworks connection, needed to list the server in the game browser on a alternate port, you need to add `-p <PORT>:<PORT>/udp` to your Docker command;
 - `R2_SV_PORT`, the listen port for the game server, needed to list the server in the game browser on a alternate port, you also need to add `-p <PORT>:<PORT>/udp` to your Docker command.
 - `R2_TAGS`, the tags the server will have in the server browser.
+- `R2_GAMEMODE`, the type of gamemode for the run, defaulting to `ClassicRun`. Supported options:
+    - `ClassicRun` (Standard)
+    - `InfiniteTowerRun` (Simulacrum)
 
 You shouldn't need to change `R2_QUERY_PORT` and `R2_SV_PORT` if you are not planning on hosting more server instances on the same machine/IP.
 

--- a/default_config.cfg
+++ b/default_config.cfg
@@ -16,3 +16,5 @@ steam_server_steam_port 0;
 sv_password "${R2_PSW}";
 // Set comma-delimited custom tags
 sv_custom_tags "${R2_TAGS}";
+// Set the gamemode (Classic or Simulacrum)
+gamemode "${R2_GAMEMODE}";


### PR DESCRIPTION
Looks like switching the lobby to a Simulacrum run is fairly straightforward, and can just use the existing system for environmental variables.