### PR TITLE
Some added clean up for running the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,6 @@ COPY default_config.cfg ${STEAMAPPDIR}/default_config.cfg
 
 WORKDIR ${STEAMAPPDIR}
 
-VOLUME ${STEAMAPPDIR}
-
 # Check for message to see if server is ready
 HEALTHCHECK --interval=10s --timeout=5s \
     CMD grep "Steamworks Server IP discovered" "${STEAMAPPDIR}/entry.log" || exit 1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You need [Docker](https://docs.docker.com/get-docker/) installed. On Debian syst
 Run the Docker container with:
 
 ```bash
-docker run -p 27015:27015/udp avivace/ror2server:latest
+docker run --rm -p 27015:27015/udp avivace/ror2server:latest
 ```
 
 Players need to start Risk of Rain 2, open the console pressing <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>\`</kbd> and insert this command:


### PR DESCRIPTION
Added `--rm` to the docker run example. For people unfamiliar with Docker, if they start and stop the container multiple times, each container instance will be saved and take up extra disk space. It's good practice to use `--rm` unless you are specifically starting and stopping the same container for a good reason. 

Removed `VOLUME` statement from `Dockerfile` - from my understanding this statement is unneeded and doesn't functionally serve a purpose. Additionally, if you stop the container, the volume will stay on your disk, and take up around 2 GB on the disk per container stopped since it contains the Risk of Rain binary. 