### PR TITLE
Move install to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,6 @@ COPY default_config.cfg ${STEAMAPPDIR}/default_config.cfg
 
 WORKDIR ${STEAMAPPDIR}
 
-VOLUME ${STEAMAPPDIR}
-
 # Check for message to see if server is ready
 HEALTHCHECK --interval=10s --timeout=5s \
     CMD grep "Steamworks Server IP discovered" "${STEAMAPPDIR}/entry.log" || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,8 @@ COPY default_config.cfg ${STEAMAPPDIR}/default_config.cfg
 
 WORKDIR ${STEAMAPPDIR}
 
+RUN "${STEAMCMD}" +force_install_dir "${STEAMAPPDIR}" +login anonymous +@sSteamCmdForcePlatformType windows +app_update "${STEAMAPPID}" +quit
+
 # Check for message to see if server is ready
 HEALTHCHECK --interval=10s --timeout=5s \
     CMD grep "Steamworks Server IP discovered" "${STEAMAPPDIR}/entry.log" || exit 1

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You need [Docker](https://docs.docker.com/get-docker/) installed. On Debian syst
 Run the Docker container with:
 
 ```bash
-docker run -p 27015:27015/udp avivace/ror2server:latest
+docker run --rm -p 27015:27015/udp avivace/ror2server:latest
 ```
 
 Players need to start Risk of Rain 2, open the console pressing <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>\`</kbd> and insert this command:

--- a/entry.sh
+++ b/entry.sh
@@ -23,8 +23,6 @@ function maybe_replace_wine()
 function execute()
 {
     maybe_replace_wine
-    echo "Installing Risk of Rain 2 server..."
-    "${STEAMCMD}" +force_install_dir "${STEAMAPPDIR}" +login anonymous +@sSteamCmdForcePlatformType windows +app_update "${STEAMAPPID}" +quit
 
     echo "Generating server configuration..."
     envsubst < "default_config.cfg" > "${STEAMAPPDIR}/Risk of Rain 2_Data/Config/server.cfg"


### PR DESCRIPTION
This change moves the install of ror2 to the building of the container. This allows the user to start and stop the server without having to redownload the game each time.